### PR TITLE
Disable decompounder in ngram_search analysis

### DIFF
--- a/es/index_settings.json
+++ b/es/index_settings.json
@@ -24,7 +24,6 @@
 				"filter": [
 					"lowercase",
 					"german_normalization",
-					"photon_hyphenation_decompounder",
 					"asciifolding"
 				]
 			},


### PR DESCRIPTION
The synonym generating filters for decompounding and for classification terms cannot be used together because they both change the position length of a token in a way that does not take into account changes of previously run synonym filters.

To work around this issue, this commit disables the photon_hyphenation_decompounder for the saerch_ngram analyser which is the only one that uses both filters.